### PR TITLE
[WFLY-3154] : Operation which require server reload should check if some...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ReloadRequiredWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReloadRequiredWriteAttributeHandler.java
@@ -45,7 +45,13 @@ public class ReloadRequiredWriteAttributeHandler extends AbstractWriteAttributeH
 
     @Override
     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> voidHandback) throws OperationFailedException {
-        return true;
+//      Some might ask why we are comparing a resolvedValue with the currentValuewhich is not resolved.
+//      Well the issue is that the context that would permit to resolve the currentValue might have changed thus
+//      the resolved value for the currentValue wouldn't be correct.
+//      In fact we just can't resolve the currentValue without any doubt. When in doubt reload, so we will return true in this case.
+//      For example if the currentValue is ${foo} and that for some reason foo has changed in between, then we should reload even if now ${foo} resolves
+//      as resolvedValue.
+        return !resolvedValue.equals(currentValue);
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.controller.test;
+
+import java.util.Locale;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.ResourceBuilder;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_REQUIRES_RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROCESS_STATE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_REQUIRED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+public class WriteAttributeOperationTestCase extends AbstractControllerTestBase {
+
+    private static final OperationDefinition SETUP_OP_DEF = new SimpleOperationDefinitionBuilder("setup", new NonResolvingResourceDescriptionResolver())
+            .setPrivateEntry()
+            .build();
+
+    protected static final SimpleAttributeDefinition TIMEOUT = new SimpleAttributeDefinitionBuilder("timeout", ModelType.LONG)
+            .setAllowNull(true)
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setDefaultValue(new ModelNode(true))
+            .setAllowExpression(true)
+            .setMaxSize(1)
+            .build();
+
+    protected static final SimpleAttributeDefinition CLASSIC = new SimpleAttributeDefinitionBuilder("classic", ModelType.BOOLEAN)
+            .setAllowNull(true)
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setDefaultValue(new ModelNode(true))
+            .setAllowExpression(true)
+            .setMaxSize(1)
+            .build();
+
+    private static final OperationStepHandler handler = new ReloadRequiredWriteAttributeHandler(CLASSIC, TIMEOUT);
+
+    @Override
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+        rootRegistration.registerOperationHandler(SETUP_OP_DEF, new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                final ModelNode model = new ModelNode();
+                //Atttributes
+                model.get("profile", "profileA", "subsystem", "subsystem1", "classic").set(true);
+                model.get("profile", "profileA", "subsystem", "subsystem1", "timeout").set(1000L);
+                createModel(context, model);
+                context.stepCompleted();
+            }
+        }
+        );
+        ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
+                new NonResolvingResourceDescriptionResolver())
+                .addReadOnlyAttribute(SimpleAttributeDefinitionBuilder.create("name", ModelType.STRING, false).setMinSize(1).build())
+                .build();
+
+        ManagementResourceRegistration profileReg = rootRegistration.registerSubModel(profileDef);
+
+        ManagementResourceRegistration profileSub1Reg = profileReg.registerSubModel(PathElement.pathElement("subsystem", "subsystem1"), new DescriptionProvider() {
+            @Override
+            public ModelNode getModelDescription(Locale locale) {
+                ModelNode node = new ModelNode();
+                node.get(DESCRIPTION).set("A test subsystem 1");
+                node.get(ATTRIBUTES, "classic", TYPE).set(ModelType.BOOLEAN);
+                node.get(ATTRIBUTES, "classic", DESCRIPTION).set("Is classic");
+                node.get(ATTRIBUTES, "classic", REQUIRED).set(false);
+                node.get(ATTRIBUTES, "timeout", RESTART_REQUIRED).set("all-services");
+                node.get(ATTRIBUTES, "timeout", TYPE).set(ModelType.LONG);
+                node.get(ATTRIBUTES, "timeout", DESCRIPTION).set("A r/o long");
+                node.get(ATTRIBUTES, "timeout", REQUIRED).set(true);
+                node.get(ATTRIBUTES, "timeout", RESTART_REQUIRED).set("all-services");
+                return node;
+            }
+        });
+        profileSub1Reg.registerReadWriteAttribute(CLASSIC, null, handler);
+        profileSub1Reg.registerReadWriteAttribute(TIMEOUT, null, handler);
+    }
+
+    @Test
+    public void testWriteReloadAttribute() throws Exception {
+
+        //Just make sure it works as expected for an existant resource
+        ModelNode operation = createOperation(READ_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NAME).set("classic");
+        ModelNode result = executeForResult(operation);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getType(), is(ModelType.BOOLEAN));
+        assertThat(result.asBoolean(), is(true));
+
+        operation = createOperation(READ_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NAME).set("timeout");
+        result = executeForResult(operation);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getType(), is(ModelType.LONG));
+        assertThat(result.asLong(), is(1000L));
+
+        ModelNode write = createOperation(WRITE_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        write.get(NAME).set("classic");
+        write.get(VALUE).set(false);
+        result = executeCheckNoFailure(write);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD).asBoolean(), is(true));
+        assertThat(result.get(RESPONSE_HEADERS, PROCESS_STATE).asString(), is(ControlledProcessState.State.RELOAD_REQUIRED.toString()));
+
+        write = createOperation(WRITE_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        write.get(NAME).set("timeout");
+        write.get(VALUE).set(10000L);
+        result = executeCheckNoFailure(write);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD).asBoolean(), is(true));
+        assertThat(result.get(RESPONSE_HEADERS, PROCESS_STATE).asString(), is(ControlledProcessState.State.RELOAD_REQUIRED.toString()));
+    }
+
+    @Test
+    public void testWriteReloadAttributeWithoutChange() throws Exception {
+
+        //Just make sure it works as expected for an existant resource
+        ModelNode operation = createOperation(READ_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NAME).set("classic");
+        ModelNode result = executeForResult(operation);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getType(), is(ModelType.BOOLEAN));
+        assertThat(result.asBoolean(), is(true));
+
+        operation = createOperation(READ_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NAME).set("timeout");
+        result = executeForResult(operation);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getType(), is(ModelType.LONG));
+        assertThat(result.asLong(), is(1000L));
+
+        ModelNode rewrite = createOperation(WRITE_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        rewrite.get(NAME).set("classic");
+        rewrite.get(VALUE).set(true);
+        result = executeCheckNoFailure(rewrite);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD).isDefined(), is(false));
+        assertThat(result.get(RESPONSE_HEADERS, PROCESS_STATE).isDefined(),  is(false));
+
+        rewrite = createOperation(WRITE_ATTRIBUTE_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        rewrite.get(NAME).set("timeout");
+        rewrite.get(VALUE).set(1000L);
+        result = executeCheckNoFailure(rewrite);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD).isDefined(), is(false));
+        assertThat(result.get(RESPONSE_HEADERS, PROCESS_STATE).isDefined(),  is(false));
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadOpsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadOpsTestCase.java
@@ -1,0 +1,199 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.management.cli;
+
+import java.io.IOException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
+
+/**
+ * 
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2013 Red Hat, inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ReloadOpsTestCase extends AbstractCliTestBase {
+
+    public static final String DEFAULT_JBOSSAS = "default-jbossas";
+    public static final String DEPLOYMENT_NAME = "DUMMY";
+    private static final long TIMEOUT = 100000L;
+    
+    @ArquillianResource
+    private static ContainerController container;
+    
+    //NOTE: BeforeClass is not subject to ARQ injection.
+    @Before
+    public void initServer() throws Exception {
+        container.start(DEFAULT_JBOSSAS);
+        initCLI();
+    }
+
+    @After
+    public void closeServer() throws Exception {
+        closeCLI();
+        container.stop(DEFAULT_JBOSSAS);
+    }
+
+    @Deployment(name = DEPLOYMENT_NAME, managed = false)
+    @TargetsContainer(DEFAULT_JBOSSAS)
+    public static Archive<?> getDeployment() {
+        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
+        ja.addClass(ReloadOpsTestCase.class);
+        return ja;
+    }
+
+    @Test
+    public void testWriteAttribvuteWithReload() throws Exception {
+        ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+        cli.sendLine("/subsystem=jpa:read-attribute(name=default-extended-persistence-inheritance)");
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        String value = (String) result.getResult();
+        assertThat(value, is("DEEP"));
+        cli.sendLine("/subsystem=jpa:write-attribute(name=default-extended-persistence-inheritance, value=SHALLOW)");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        checkResponseHeadersForProcessState(result);
+        reloadServer(managementClient, TIMEOUT);
+        cli.sendLine("/subsystem=jpa:read-attribute(name=default-extended-persistence-inheritance)");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        value = (String) result.getResult();
+        assertThat(value, is("SHALLOW"));
+        cli.sendLine("/subsystem=jpa:write-attribute(name=default-extended-persistence-inheritance, value=SHALLOW)");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        assertNoProcessState(result);
+        cli.sendLine("/subsystem=jpa:read-attribute(name=default-extended-persistence-inheritance)");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        value = (String) result.getResult();
+        assertThat(value, is("SHALLOW"));
+    }
+    
+    private void reloadServer(ManagementClient managementClient, long timeout) throws Exception {
+        executeReload(managementClient.getControllerClient());
+        waitForLiveServerToReload(timeout);
+    }
+
+     private void executeReload(ModelControllerClient client) throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(OP).set("reload");
+        try {
+            Assert.assertTrue(Operations.isSuccessfulOutcome(client.execute(operation)));
+        } catch (IOException e) {
+            final Throwable cause = e.getCause();
+            if (cause instanceof ExecutionException) {
+                // ignore, this might happen if the channel gets closed before we got the response
+            } else {
+                throw e;
+            }
+        } finally {
+            client.close();
+        }
+    }
+
+    private void waitForLiveServerToReload(long timeout) throws Exception {
+        long start = System.currentTimeMillis();
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        operation.get(NAME).set("server-state");
+        while (System.currentTimeMillis() - start < timeout) {
+            ModelControllerClient liveClient = ModelControllerClient.Factory.create(
+                    TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort());
+            try {
+                ModelNode result = liveClient.execute(operation);
+                if ("running".equals(result.get(RESULT).asString())) {
+                    return;
+                }
+            } catch (IOException e) {
+            } finally {
+                IoUtils.safeClose(liveClient);
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+        fail("Live Server did not reload in the imparted time.");
+    }
+
+    protected void checkResponseHeadersForProcessState(CLIOpResult result) {
+        assertNotNull("No response headers!", result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS));
+        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
+        Object processState = responseHeaders.get("process-state");
+        assertNotNull("No process state in response-headers!", processState);
+        assertTrue("Process state is of wrong type!", processState instanceof String);
+        assertEquals("Wrong content of process-state header", "reload-required", (String) processState);
+
+    }
+    
+    protected void assertNoProcessState(CLIOpResult result) {
+        if(result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS) == null){
+            return;
+        }
+        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
+        Object processState = responseHeaders.get("process-state");
+        assertNull(processState);
+        
+    }
+}


### PR DESCRIPTION
...thing was changed.

Adding tests and modifying ReloadRequiredWriteAttributeHandler.
In the implementation we are comparing currentValue which is not a resolved with resolvedValue, this is done on purpose.
As the context might have changed we can't resolve currentValue being sure that the resolved value is the effective value.

Jira : https://issues.jboss.org/browse/WFLY-3154
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=976228
